### PR TITLE
ensure bytes are sent original bug #356 from grunt-webfont

### DIFF
--- a/tasks/bin/eotlitetool.py
+++ b/tasks/bin/eotlitetool.py
@@ -373,7 +373,7 @@ def make_eot_name_headers(fontdata, nameTableDir):
         else:
             nameheaders.append(struct.pack('4x'))  # len = 0, padding = 0
 
-    return ''.join(nameheaders)
+    return b''.join(nameheaders)
 
 # just return a null-string (len = 0)
 def make_root_string():
@@ -445,11 +445,11 @@ def make_eot_header(fontdata):
                         *([eotSize, fontDataSize, version, flags] + panose + [charset, italic] +
                           [weight, fsType, magicNumber] + urange + codepage + [checkSumAdjustment]))
 
-    return ''.join((fixed, nameheaders, rootstring))
+    return b''.join((fixed, nameheaders, rootstring))
 
 
 def write_eot_font(eot, header, data):
-    open(eot,'wb').write(''.join((header, data)))
+    open(eot,'wb').write(b''.join((header, data)))
     return
 
 def main():


### PR DESCRIPTION
If you want your pull request to be merged, please:

1. Explain the use case or bug you’re solving.
  - eot icons do not get created on python 3.X
2. Add tests.
  - i believe in tests, but this has been proved by local compiling :)
3. Add docs.
  - Fix to work with binary data in python3.X
